### PR TITLE
add script to synchronize deps

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -4,9 +4,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil-comp7
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- '2.7'
+numpy:
+- '1.14'

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -4,5 +4,9 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil-comp7
-numpy:
-- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+on:
+  status: {}
+  check_suite:
+    types:
+      - completed
+
+jobs:
+  regro-cf-autotick-bot-action:
+    runs-on: ubuntu-latest
+    name: regro-cf-autotick-bot-action
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: regro-cf-autotick-bot-action
+        id: regro-cf-autotick-bot-action
+        uses: regro/cf-autotick-bot-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/webservices.yml
+++ b/.github/workflows/webservices.yml
@@ -1,0 +1,12 @@
+on: repository_dispatch
+
+jobs:
+  webservices:
+    runs-on: ubuntu-latest
+    name: webservices
+    steps:
+      - name: webservices
+        id: webservices
+        uses: conda-forge/webservices-dispatch-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,26 +24,26 @@ requirements:
   - python
   - numpy
   run_constrained:
-  - meshio
-  - pyglet
-  - lxml
   - scikit-image
-  - shapely
-  - rtree
-  - networkx
-  - pycollada
-  - chardet
-  - jsonschema
   - msgpack-python
-  - xxhash
-  - scipy
-  - sympy
-  - pillow
-  - colorlog
   - requests
-  - psutil
-  - triangle
+  - pycollada
+  - shapely
+  - colorlog
+  - meshio
   - setuptools
+  - sympy
+  - jsonschema
+  - lxml
+  - xxhash
+  - rtree
+  - pyglet
+  - triangle
+  - psutil
+  - networkx
+  - scipy
+  - pillow
+  - chardet
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,24 +13,41 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
-
 requirements:
-  build: [python, pip]
-  run: [python, numpy]
-  run_constrained: [xxhash, jsonschema, colorlog, pycollada, psutil, sympy, scikit-image,
-    lxml, shapely, networkx, requests, scipy, pillow, meshio, pyglet, rtree, setuptools,
-    chardet, msgpack-python, triangle]
-
-
-
+  build:
+  - python
+  - pip
+  run:
+  - python
+  - numpy
+  run_constrained:
+  - meshio
+  - pyglet
+  - lxml
+  - scikit-image
+  - shapely
+  - rtree
+  - networkx
+  - pycollada
+  - chardet
+  - jsonschema
+  - msgpack-python
+  - xxhash
+  - scipy
+  - sympy
+  - pillow
+  - colorlog
+  - requests
+  - psutil
+  - triangle
+  - setuptools
 
 test:
   commands:
     - python -c "import trimesh"
-
 
 about:
   home: https://github.com/mikedh/trimesh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,29 +16,15 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
+
 requirements:
-  build:
-    - python
-    - pip
-  run:
-    - python
-    - numpy
-    - networkx
-    - scipy
-  run_constrained:
-    - lxml
-    - pyglet
-    - Shapely
-    - rtree
-    - sympy
-    - msgpack-python
-    - colorlog
-    - python-xxhash
-    - pillow
-    # these deps are not yet available on conda-forge
-    # - python-fcl
-    # - svg.path
-    # - meshpy
+  build: [python, pip]
+  run: [python, numpy]
+  run_constrained: [xxhash, jsonschema, colorlog, pycollada, psutil, sympy, scikit-image,
+    lxml, shapely, networkx, requests, scipy, pillow, meshio, pyglet, rtree, setuptools,
+    chardet, msgpack-python, triangle]
+
+
 
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trimesh" %}
-{% set version = "3.5.1" %}
-{% set sha256 = "ed4fe9ef13e55c2eb8f7597ee4af339474bad96f0972e798457c61e156bce5bb" %}
+{% set version = "3.5.2" %}
+{% set sha256 = "e841f8ddbe1e87796f340e4a18ac8550357500f4cd9177922f8a8d2f32ff5e2d" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trimesh" %}
-{% set version = "3.5.2" %}
-{% set sha256 = "e841f8ddbe1e87796f340e4a18ac8550357500f4cd9177922f8a8d2f32ff5e2d" %}
+{% set version = "3.5.4" %}
+{% set sha256 = "5211a799ef1870da7b20f49221ab21e64cd114023deb5559a3a43fe78bf92abe" %}
 
 package:
   name: {{ name|lower }}

--- a/update_meta.py
+++ b/update_meta.py
@@ -97,15 +97,20 @@ if __name__ == '__main__':
 
     # find the existing set of `run_constrained` package requirements
     existing = set(load['requirements']['run_constrained'])
-    if existing != ok:
-        print('packages changed: ', ok.symmetric_difference(existing))
-        load['requirements']['run_constrained'] = list(ok)
 
-        # compile result back into jinja2-template
-        wangled = '\n'.join([text[:start], yaml.dump(load), text[end:]])
-        print(f'\n\n{wangled}\n\n')
+    print('packages changed: ', ok.symmetric_difference(existing))
+    load['requirements']['run_constrained'] = list(ok)
 
-        # only write the result if the user says yes
-        if (input(f'write to {meta_path}? (y/n)').lower().strip() == 'y'):
-            with open(meta_path, 'w') as f:
-                f.write(wangled)
+    # compile result back into jinja2-template
+    wangled = '\n'.join([text[:start],
+                         yaml.dump(load, default_flow_style=False),
+                         text[end:]]).strip()
+    # cheap hack to replace 2+ blank lines with a single blank line
+    for i in range(10):
+        wangled = wangled.replace('\n\n\n', '\n\n')
+    print(f'\n\n{wangled}\n\n')
+
+    # only write the result if the user says yes
+    if (input(f'write to {meta_path}? (y/n)').lower().strip() == 'y'):
+        with open(meta_path, 'w') as f:
+            f.write(wangled)

--- a/update_meta.py
+++ b/update_meta.py
@@ -104,7 +104,7 @@ if __name__ == '__main__':
     # compile result back into jinja2-template
     wangled = '\n'.join([text[:start],
                          yaml.dump(load, default_flow_style=False),
-                         text[end:]]).strip()
+                         text[end:]]).strip() + '\n'
     # cheap hack to replace 2+ blank lines with a single blank line
     for i in range(10):
         wangled = wangled.replace('\n\n\n', '\n\n')

--- a/update_meta.py
+++ b/update_meta.py
@@ -1,0 +1,111 @@
+"""
+Synchronize the conda-forge recipe with the requirements from
+trimesh's latest setup.py on github.
+"""
+import yaml
+import requests
+
+
+def feedstock_name(package):
+    """
+    Check to see if a package has a conda-forge feedstock
+
+    Parameters
+    ------------
+    package : str
+      Name of a package to check
+
+    Returns
+    -------------
+    name : str or None
+      None if it doesn't exist
+    """
+    # base url to check
+    base = 'https://github.com/conda-forge/{}-feedstock'
+
+    #check_yes = requests.get(base.format('triangle'))
+    #check_no = requests.get(base.format('blahahshdrraaa1123'))
+    #assert check_no.status_code == 404
+    #assert check_yes.status_code == 200
+
+    # make sure name is clean
+    package = package.lower().strip()
+
+    # map packages to different name if known here
+    name_map = {'msgpack': 'msgpack-python'}
+    if package in name_map:
+        package = name_map[package]
+
+    # check the feedstock on github
+    fetch = requests.get(base.format(package))
+    exists = fetch.status_code == 200
+
+    print(f'{package} exists={exists}')
+
+    if exists:
+        return package
+    return None
+
+
+def fetch_requirements():
+    """
+    Fetch the latest `requirements_all` from trimesh's `setup.py`
+    and then clean it up into `exec`-able string
+
+    Returns
+    ----------
+    code : str
+      Code containing requirements from trimesh
+    """
+    d = requests.get(
+        'https://raw.githubusercontent.com/mikedh/trimesh/master/setup.py')
+    lines = str.splitlines(d.content.decode('utf-8'))
+    current = None
+    saved = []
+    for line in lines:
+        if current is not None:
+            current.append(line)
+            if ')' in line:
+                saved.append('\n'.join(current))
+                current = None
+        elif line.lower().startswith('requirements_'):
+            current = [line]
+    return '\n'.join(saved)
+
+
+if __name__ == '__main__':
+    # load `requirements_all` from trimesh's latest setup.py on github
+    exec(fetch_requirements())
+
+    # find the name on conda-forge of the trimesh requirements
+    # remove any None-results with a set difference
+    ok = set([feedstock_name(pack)
+              for pack in requirements_all]).difference([None])
+
+    # now update the run_constrained section with our results
+    # NOT a yaml file: actually a jinja2 template for a yaml file
+    meta_path = 'recipe/meta.yaml'
+    with open(meta_path, 'r') as f:
+        text = f.read()
+
+    # use string wangling to find requirements section
+    start = text.find('requirements')
+    # look for ending whitespace- this is brittle!
+    end = text.find('\n\n', start)
+    # load requirements section from YAML
+    load = yaml.load(text[start:end])
+
+    # find the existing set of `run_constrained` package requirements
+    existing = set(load['requirements']['run_constrained'])
+    if existing != ok:
+        print('packages changed: ', ok.symmetric_difference(existing))
+        load['requirements']['run_constrained'] = list(ok)
+
+        # compile result back into jinja2-template
+        wangled = '\n'.join([text[:start], yaml.dump(load), text[end:]])
+        print(f'\n\n{wangled}\n\n')
+
+        # only write the result if the user says yes
+        if (input(f'write to {meta_path}? (y/n)').lower().strip() == 'y'):
+            with open(meta_path, 'w') as f:
+                f.write(wangled)


### PR DESCRIPTION
### Checklist

* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

### Summary

Updates `meta.yaml` `run_constrained` to be synchronized with upstream package, and adds a helper script to do this automatically. 

Closes https://github.com/mikedh/trimesh/issues/770
